### PR TITLE
Refactor In method and update SimpraExpressionTests

### DIFF
--- a/src/AltaSoft.Simpra/Types/SimpraBool.cs
+++ b/src/AltaSoft.Simpra/Types/SimpraBool.cs
@@ -60,7 +60,7 @@ internal struct SimpraBool : ISimpraType<bool>
     public static bool operator !=(SimpraBool a, bool b) => !(a == b);
 
     //
-    public static SimpraBool In(SimpraBool value, SimpraList<SimpraBool, bool> lookup, bool _) => lookup.Contains(value);
+    public static SimpraBool In(SimpraBool value, SimpraList<SimpraBool, bool> lookup) => lookup.Contains(value);
 
     public readonly SimpraBool Min(SimpraBool b) => new(Value && b.Value);
     public readonly SimpraBool Max(SimpraBool b) => new(Value || b.Value);

--- a/src/AltaSoft.Simpra/Types/SimpraDate.cs
+++ b/src/AltaSoft.Simpra/Types/SimpraDate.cs
@@ -69,7 +69,7 @@ internal struct SimpraDate : ISimpraType<DateTime>
     public static bool operator <=(SimpraDate a, SimpraDate b) => a.Value <= b.Value;
 
     //
-    public static SimpraBool In(SimpraDate value, SimpraList<SimpraDate, DateTime> lookup, bool _) => lookup.Contains(value);
+    public static SimpraBool In(SimpraDate value, SimpraList<SimpraDate, DateTime> lookup) => lookup.Contains(value);
 
     public readonly SimpraDate Min(SimpraDate b) => Value.Ticks < b.Value.Ticks ? Value : b.Value;
     public readonly SimpraDate Max(SimpraDate b) => Value.Ticks > b.Value.Ticks ? Value : b.Value;

--- a/src/AltaSoft.Simpra/Types/SimpraNumber.cs
+++ b/src/AltaSoft.Simpra/Types/SimpraNumber.cs
@@ -98,7 +98,7 @@ internal struct SimpraNumber : ISimpraType<decimal>
     public static bool operator <=(SimpraNumber a, SimpraNumber b) => a.Value <= b.Value;
 
     //
-    public static SimpraBool In(SimpraNumber value, SimpraList<SimpraNumber, decimal> lookup, bool _) => lookup.Contains(value);
+    public static SimpraBool In(SimpraNumber value, SimpraList<SimpraNumber, decimal> lookup) => lookup.Contains(value);
 
     public readonly SimpraNumber Min(SimpraNumber b) => new(Math.Min(Value, b.Value));
     public readonly SimpraNumber Max(SimpraNumber b) => new(Math.Max(Value, b.Value));

--- a/tests/AltaSoft.Simpra.tests/SimpraExpressionTests.cs
+++ b/tests/AltaSoft.Simpra.tests/SimpraExpressionTests.cs
@@ -101,12 +101,28 @@ public class SimpraExpressionTests
     }
 
     [Fact]
-    public void Expression_Should_ReturnTrue_When_DynamicListContainsMatchingItem()
+    public void Expression_Should_ReturnTrue_When_DynamicStringListContainsMatchingItem()
     {
         const string expressionCode =
             """
             let dynamicList = ListSomeCountries('countries')
             return 'RU' in dynamicList or 'US' in dynamicList
+            """;
+
+        var simpra = new Simpra();
+        var model = GetTestModel();
+        var result = simpra.Execute<bool, TestModel, TestFunctions>(model, new TestFunctions(), expressionCode);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Expression_Should_ReturnTrue_When_DynamicIntListContainsMatchingItem()
+    {
+        const string expressionCode =
+            """
+            let dynamicList = ListOfCustomerIds('Good')
+            return 1 in dynamicList
             """;
 
         var simpra = new Simpra();
@@ -1063,6 +1079,11 @@ public class SimpraExpressionTests
         public static string[] ListSomeCountries(string key)
         {
             return ["RU", "BE"];
+        }
+
+        public static int[] ListOfCustomerIds(string key)
+        {
+            return [1, 2];
         }
 
 #pragma warning disable S2325


### PR DESCRIPTION
Removed unused boolean parameter from In method in SimpraBool, SimpraDate, and SimpraNumber structs. Renamed test method in SimpraExpressionTests to specify string list. Added new test method for dynamic integer list and a helper method to return a list of customer IDs.