### PR TITLE
Bump version to 1.0.12 and enhance interface support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
 	<Product>Simpra</Product>
 	<Company>ALTA Software llc.</Company>
 	<Copyright>Copyright © 2024 ALTA Software llc.</Copyright>
-	<Version>1.0.11</Version>
+	<Version>1.0.12</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AltaSoft.Simpra/Visitor/SimpraParserVisitor.tools.cs
+++ b/src/AltaSoft.Simpra/Visitor/SimpraParserVisitor.tools.cs
@@ -232,9 +232,23 @@ internal partial class SimpraParserVisitor<TResult, TModel>
         var asyncMethodName = methodName + "Async";
 
         // Get all methods matching the method name
-        var methods = targetType.GetMethods(bindingFlags)
-            .Where(m => m.Name == methodName || m.Name == asyncMethodName)
-            .ToList();
+        IEnumerable<MethodInfo> methods;
+
+        if (targetType.IsInterface)
+        {
+            // Include methods from the interface and all inherited interfaces
+            methods = targetType
+                .GetInterfaces()
+                .Append(targetType)
+                .SelectMany(i => i.GetMethods(bindingFlags));
+        }
+        else
+        {
+            // For class or struct types
+            methods = targetType.GetMethods(bindingFlags);
+        }
+
+        methods = methods.Where(m => m.Name == methodName || m.Name == asyncMethodName);
 
         // Track the best match and its score
         MethodInfo? bestMatch = null;

--- a/tests/AltaSoft.Simpra.tests/SimpraExpressionTests.cs
+++ b/tests/AltaSoft.Simpra.tests/SimpraExpressionTests.cs
@@ -4,6 +4,35 @@ namespace AltaSoft.Simpra.Tests;
 
 public class SimpraExpressionTests
 {
+    [Fact]
+    public void CallInterfaceFunctionFromSimpra_ShouldReturnCorrectValue()
+    {
+        const string expressionCode =
+            """
+            return Upper('test')
+            """;
+
+        var simpra = new Simpra();
+        var model = GetTestModel();
+        var result = simpra.Execute<string, TestModel, IFunctions>(model, new TestFunctions(), expressionCode);
+        Assert.Equal("TEST", result);
+
+    }
+
+    [Fact]
+    public void CallBaseInterfaceFunctionFromSimpra_ShouldReturnCorrectValue()
+    {
+        const string expressionCode =
+            """
+            return Lower('TEST')
+            """;
+
+        var simpra = new Simpra();
+        var model = GetTestModel();
+        var result = simpra.Execute<string, TestModel, IFunctions>(model, new TestFunctions(), expressionCode);
+        Assert.Equal("test", result);
+
+    }
 
     [Fact]
     public void CallBaseStaticFunctionFromSimpra_ShouldReturnCorrectValue()
@@ -1579,7 +1608,19 @@ public class SimpraExpressionTests
         public static string CallBaseStaticMethod() => "BaseStaticMethod";
         public static string CallBaseMethod() => "BaseMethod";
     }
-    public class TestFunctions : BaseFunctions
+    public interface IFunctions : IBaseFunctions
+    {
+        string Upper(string str);
+
+    }
+
+    public interface IBaseFunctions
+    {
+        string Lower(string str);
+
+    }
+
+    public class TestFunctions : BaseFunctions, IFunctions
     {
         // ReSharper disable UnusedMember.Global
         public static string[] ListSomeCountries(string key)


### PR DESCRIPTION
- Updated version number in `Directory.Build.props`.
- Refactored method retrieval in `SimpraParserVisitor.tools.cs` to support interface methods.
- Added tests for `Upper` and `Lower` methods in `SimpraExpressionTests.cs`.
- Introduced `IFunctions` and `IBaseFunctions` interfaces for better function contracts.
- Updated `TestFunctions` class to implement the new `IFunctions` interface.